### PR TITLE
Fix array literal property access

### DIFF
--- a/lib/execute/evaluate.test.ts
+++ b/lib/execute/evaluate.test.ts
@@ -190,6 +190,12 @@ describe("evaluate", () => {
         expect(result.toString()).toEqual("[9]");
       });
 
+      it("accesses properties on array literals", () => {
+        const input = "[.a 1; .b 2;].a";
+        const result = evaluate(input);
+        expect(result.toString()).toEqual("[1]");
+      });
+
       it("groups properties explicitly", () => {
         const input = "([9,8].0)+([7,6].1)";
         const result = evaluate(input);

--- a/lib/frames/frame-array.ts
+++ b/lib/frames/frame-array.ts
@@ -22,7 +22,7 @@ export class FrameArray extends FrameList {
 
   public override in(contexts: Array<Frame> = [Frame.nil]): Frame {
     const array = this.array_eval(contexts);
-    return new FrameArray(array);
+    return new FrameArray(array, this.meta_copy());
   }
 
   public override get(key: string, origin: MetaFrame = this): Frame {

--- a/lib/frames/frame-name.ts
+++ b/lib/frames/frame-name.ts
@@ -1,4 +1,5 @@
 import { Frame } from "./frame.ts";
+import { FrameArray } from "./frame-array.ts";
 import { FrameAtom } from "./frame-atom.ts";
 import { FrameOperator, FrameSymbol } from "./frame-symbol.ts";
 import type { ISourced } from "./meta-frame.ts";
@@ -16,8 +17,18 @@ export class FrameName extends FrameAtom implements ISourced {
     this.source = source;
   }
 
+  private bindingTarget(contexts: Frame[]): Frame {
+    for (let i = contexts.length - 1; i >= 0; i--) {
+      const context = contexts[i];
+      if (context instanceof FrameArray) {
+        return context;
+      }
+    }
+    return contexts[0];
+  }
+
   public override in(contexts = [Frame.nil]): Frame {
-    const out = contexts[0];
+    const out = this.bindingTarget(contexts);
     const setter = this.data.setter(out);
     return setter;
   }


### PR DESCRIPTION
## Summary\n- bind .name setters to array literal context\n- preserve array metadata during evaluation\n- add regression test for issue #198\n\n## Testing\n- deno test lib/execute/evaluate.test.ts